### PR TITLE
Use parallel stream for blame to avoid OOM

### DIFF
--- a/sonar-scm-git-plugin/src/test/java/org/sonarsource/scm/git/JGitBlameCommandTest.java
+++ b/sonar-scm-git-plugin/src/test/java/org/sonarsource/scm/git/JGitBlameCommandTest.java
@@ -29,8 +29,6 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.apache.commons.io.FileUtils;
@@ -291,22 +289,4 @@ public class JGitBlameCommandTest {
       throw new IllegalStateException(format("Fail to unzip %s to %s", zip, toDir), e);
     }
   }
-
-  @Test
-  public void coverInterruptedException() throws Exception {
-    Future<Void> f = new CompletableFuture<Void>() {
-      public Void get() throws InterruptedException, java.util.concurrent.ExecutionException {
-        throw new InterruptedException();
-      };
-    };
-    JGitBlameCommand.waitForTaskToComplete(Arrays.asList(f));
-
-    // Clear the interrupted flag to not break Junit thread
-    try {
-      Thread.interrupted();
-    } catch (Exception e) {
-
-    }
-  }
-
 }


### PR DESCRIPTION
We have a very large code base and Sonar was failing on a workstation with 32Gb of RAM and 16 core CPU upon first run with an OOM (see stacktrace). This fix has let me analyze the project.
I suppose more fixes could be done, but this fix have definitely made things better in my environment.

> Caused by: java.lang.OutOfMemoryError: Java heap space
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.PackFile.read(PackFile.java:665)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.WindowCache.load(WindowCache.java:289)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.WindowCache.getOrLoad(WindowCache.java:368)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.WindowCache.get(WindowCache.java:179)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.WindowCursor.pin(WindowCursor.java:338)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.WindowCursor.copy(WindowCursor.java:239)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.PackFile.readFully(PackFile.java:574)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.PackFile.load(PackFile.java:736)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.PackFile.get(PackFile.java:263)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openPackedObject(ObjectDirectory.java:420)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openPackedFromSelfOrAlternate(ObjectDirectory.java:389)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openPackedFromSelfOrAlternate(ObjectDirectory.java:393)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openObject(ObjectDirectory.java:381)
> [02:04:32]	at org.eclipse.jgit.internal.storage.file.WindowCursor.open(WindowCursor.java:156)
> [02:04:32]	at org.eclipse.jgit.treewalk.CanonicalTreeParser.reset(CanonicalTreeParser.java:214)
> [02:04:32]	at org.eclipse.jgit.treewalk.CanonicalTreeParser.createSubtreeIterator0(CanonicalTreeParser.java:248)
> [02:04:32]	at org.eclipse.jgit.treewalk.CanonicalTreeParser.createSubtreeIterator(CanonicalTreeParser.java:226)
> [02:04:32]	at org.eclipse.jgit.treewalk.CanonicalTreeParser.createSubtreeIterator(CanonicalTreeParser.java:70)
> [02:04:32]	at org.eclipse.jgit.treewalk.TreeWalk.enterSubtree(TreeWalk.java:1216)
> [02:04:32]	at org.eclipse.jgit.treewalk.TreeWalk.next(TreeWalk.java:834)
> [02:04:32]	at org.eclipse.jgit.diff.DiffEntry.scan(DiffEntry.java:184)
> [02:04:32]	at org.eclipse.jgit.diff.DiffEntry.scan(DiffEntry.java:139)
> [02:04:32]	at org.eclipse.jgit.diff.DiffEntry.scan(DiffEntry.java:116)
> [02:04:32]	at org.eclipse.jgit.blame.BlameGenerator.findRename(BlameGenerator.java:974)
> [02:04:32]	at org.eclipse.jgit.blame.BlameGenerator.processOne(BlameGenerator.java:612)
> [02:04:32]	at org.eclipse.jgit.blame.BlameGenerator.next(BlameGenerator.java:496)
> [02:04:32]	at org.eclipse.jgit.blame.BlameResult.computeAll(BlameResult.java:239)
> [02:04:32]	at org.eclipse.jgit.blame.BlameGenerator.computeBlameResult(BlameGenerator.java:450)
> [02:04:32]	at org.eclipse.jgit.api.BlameCommand.call(BlameCommand.java:230)
> [02:04:32]	at org.sonarsource.scm.git.JGitBlameCommand.blame(JGitBlameCommand.java:89)
> [02:04:32]	at org.sonarsource.scm.git.JGitBlameCommand.lambda$blame$0(JGitBlameCommand.java:60)
> [02:04:32]	at org.sonarsource.scm.git.JGitBlameCommand$$Lambda$1001/325283426.accept(Unknown Source)