### PR TITLE
bugfix: GitScmProviderBefore77 should check for upstreams as well as …

### DIFF
--- a/sonar-scm-git-plugin/src/test/java/org/sonarsource/scm/git/GitScmProviderBefore77Test.java
+++ b/sonar-scm-git-plugin/src/test/java/org/sonarsource/scm/git/GitScmProviderBefore77Test.java
@@ -378,6 +378,25 @@ public class GitScmProviderBefore77Test {
   }
 
   @Test
+  public void branchChangedFiles_falls_back_to_upstream_ref() throws IOException, GitAPIException {
+    git.branchCreate().setName("b1").call();
+    git.checkout().setName("b1").call();
+    createAndCommitFile("file-b1");
+
+    Path worktree2 = temp.newFolder().toPath();
+    Git.cloneRepository()
+      .setURI(worktree.toString())
+      .setRemote("upstream")
+      .setDirectory(worktree2.toFile())
+      .call();
+
+    assertThat(newScmProvider().branchChangedFiles("master", worktree2))
+    .containsOnly(worktree2.resolve("file-b1"));
+    verifyZeroInteractions(analysisWarnings);
+
+  }
+  
+  @Test
   public void branchChangedFiles_should_return_null_when_branch_nonexistent() {
     assertThat(newScmProvider().branchChangedFiles("nonexistent", worktree)).isNull();
   }
@@ -423,7 +442,7 @@ public class GitScmProviderBefore77Test {
     };
     assertThat(provider.branchChangedFiles("branch", worktree)).isNull();
 
-    String warning = "Could not find ref 'branch' in refs/heads or refs/remotes/origin."
+    String warning = "Could not find ref 'branch' in refs/heads or refs/remotes/upstream or refs/remotes/origin."
       + " You may see unexpected issues and changes. Please make sure to fetch this ref before pull request analysis.";
     verify(analysisWarnings).addUnique(warning);
   }


### PR DESCRIPTION
GitScmProviderBefore77 currentlly checks against the local, and then the origin when finding changes in a PR.  It should also check upstreams.

Jenkins (especially when using Organization Folders) uses upstreams (not origin) when building PRs.  This is especially relevant when PRs are coming from forks and not just feature branches on the origin repo.

Here is an example of what you'll see in a Jenkins log.  Without this fix, changes won't be found as Sonar cannot see either local or origin/master.

```
Fetching upstream changes from ssh://git@bitbucket.blahblah.com:7999/EAS/unicorn-demo.git
using GIT_SSH to set credentials ci-n***-ssh ssh private key for bitbucket
 > git fetch --no-tags --force --progress -- ssh://git@bitbucket.blahblah.com:7999/EAS/unicorn-demo.git +refs/heads/master:refs/remotes/upstream/master # timeout=10
Merging remotes/upstream/master commit 8ecc810dad5f5b89b13cbb7413dbdbf83d04305e into PR head commit 58c81e0c80e83f86635d5c2960060cd6d424eb55
Merge succeeded, producing 58c81e0c80e83f86635d5c2960060cd6d424eb55
Checking out Revision 58c81e0c80e83f86635d5c2960060cd6d424eb55 (PR-1)
```

That said, it seems like a bit of a judgement call on the order of refs to check (especially with the CircleCI special case).  I'm reasoning that if there is an upstream present, it should take priority over the origin, but I'm open to the reasoning of someone more familiar than me on it.
