### PR TITLE
Remove deletion hook for dogfooding

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - master
       - "dogfood/**"
-  delete:
-    branches:
-      - "dogfood/**"
 jobs:
   dogfood_merge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Dogfooding on deletions cause race conditions within the pipeline.
Handling concurrent github actions pipelines is not possible at the moment.